### PR TITLE
fix compilation by adding include statements for fcntl function

### DIFF
--- a/src/AsynchronousWriter.hpp
+++ b/src/AsynchronousWriter.hpp
@@ -12,6 +12,8 @@
 
 #if defined(HAVE_AIO_H)
 #include <aio.h>
+#include <unistd.h>
+#include <fcntl.h>
 
 struct AsynchronousWriter
 {


### PR DESCRIPTION
This just adds two include statements necessary for the fcntl system call. It fixes compilation on Ubuntu Trusty.
